### PR TITLE
Improve type restriction of parametrized routes

### DIFF
--- a/templates/front/src/components/App.tsx
+++ b/templates/front/src/components/App.tsx
@@ -4,6 +4,7 @@ import { Logger } from 'simple-logging-system';
 import Layout from '@components/layout/Layout';
 import ErrorPage from '@components/pages/error/ErrorPage';
 import Home from '@components/pages/home/Home';
+import Routes from '../routes/Routes';
 
 const logger: Logger = new Logger('App');
 
@@ -16,6 +17,10 @@ export default function App() {
       children: [
         {
           index: true,
+          element: <Home />,
+        },
+        {
+          path: Routes.PARAMETRIZED_EXAMPLE.getRawPath(),
           element: <Home />,
         },
       ],

--- a/templates/front/src/components/Routes.ts
+++ b/templates/front/src/components/Routes.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const HOME: string = '/';

--- a/templates/front/src/components/pages/error/ErrorPage.tsx
+++ b/templates/front/src/components/pages/error/ErrorPage.tsx
@@ -2,7 +2,7 @@ import Layout from '@components/layout/Layout';
 import React from 'react';
 import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom';
 import { Logger } from 'simple-logging-system';
-import { HOME } from '../../Routes';
+import Routes from '../../../routes/Routes';
 
 const logger: Logger = new Logger('ErrorPage');
 
@@ -16,7 +16,10 @@ export default function ErrorPage() {
       <Layout>
         <div>
           <h2>Page not found</h2>
-          <div><span>Sorry, we didn&apos;t find this page.&nbsp;</span><Link to={HOME}>Go to the home page</Link></div>
+          <div>
+            <span>Sorry, we didn&apos;t find this page.&nbsp;</span>
+            <Link to={Routes.HOME.getPath()}>Go to the home page</Link>
+          </div>
         </div>
       </Layout>
     );

--- a/templates/front/src/components/pages/home/Home.tsx
+++ b/templates/front/src/components/pages/home/Home.tsx
@@ -5,6 +5,8 @@ import SampleService from '@services/sample/SampleService';
 import { useOnComponentMounted } from '@lib/react-hooks-alias/ReactHooksAlias';
 import useLoader, { LoaderState } from '@lib/plume-http-react-hook-loader/promiseLoaderHook';
 import useMessages from '@i18n/hooks/messagesHook';
+import { NavigateFunction, useNavigate } from 'react-router';
+import Routes from '../../../routes/Routes';
 
 import scss from './home.module.scss';
 
@@ -13,6 +15,8 @@ export default function Home() {
   const sampleService: SampleService = getGlobalInstance(SampleService);
   const loader: LoaderState = useLoader();
   const [sample, setSample] = useState<Sample>();
+
+  const navigate: NavigateFunction = useNavigate();
 
   useOnComponentMounted(() => {
     loader.monitor(sampleService
@@ -30,6 +34,9 @@ export default function Home() {
         {loader.error && <div>Could not call API: {httpError(loader.error)}</div>}
         {sample && <div>API call success! Result: {sample.name}</div>}
       </div>
+      <button onClick={() => navigate(Routes.PARAMETRIZED_EXAMPLE.getParametrizedPath({ param: 'example' }))}>
+        Test parametrized navigation
+      </button>
     </div>
   );
 }

--- a/templates/front/src/routes/ParametrizedRoute.ts
+++ b/templates/front/src/routes/ParametrizedRoute.ts
@@ -1,0 +1,19 @@
+export default class ParametrizedRoute<T extends Record<string, unknown>> {
+  path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  getParametrizedPath(args: T): string {
+    let path: string = `${this.path}`;
+    Object.keys(args).forEach((key: string): void => {
+      path = path.replace(`:${key}`, `${args[key]}`);
+    });
+    return path;
+  }
+
+  getRawPath(): string {
+    return this.path;
+  }
+}

--- a/templates/front/src/routes/Routes.ts
+++ b/templates/front/src/routes/Routes.ts
@@ -1,0 +1,14 @@
+import ParametrizedRoute from './ParametrizedRoute';
+import NonParametrizedRoute from './UnparametrizedRoute';
+
+type ParametrizedExampleParams = {
+  param: string,
+};
+
+export default class Routes {
+  public static HOME: NonParametrizedRoute = new NonParametrizedRoute('/');
+
+  public static PARAMETRIZED_EXAMPLE: ParametrizedRoute<ParametrizedExampleParams> = new ParametrizedRoute(
+    '/parametrized/:param',
+  );
+}

--- a/templates/front/src/routes/UnparametrizedRoute.ts
+++ b/templates/front/src/routes/UnparametrizedRoute.ts
@@ -1,0 +1,11 @@
+export default class NonParametrizedRoute {
+  path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  getPath(): string {
+    return this.path;
+  }
+}


### PR DESCRIPTION
Hello Aurélien,

J'étais sur un petit projet perso et je cherchais un moyen d'améliorer le typage des paramètres des routes lors de la navigation.

Avant, on faisait quelque chose du genre : 
```tsx
  onClick={() => navigate(Routes.MY_ROUTE.replace(':id', myRouteId))}
```
Le problème c'est que id n'était pas forcement un paramètre de la route en question.

Avec mes quelques modifications, on pourrait faire : 
```tsx
  onClick={() => navigate(Routes.MY_ROUTE.getParametrizedPath({ id: myRouteId }))}
```
Et avoir une erreur TS si : 
- Le paramètre "id" n'est pas attendu
- Un paramètre est manquant
- Un paramètre n'est pas du bon type

Qu'en penses-tu ? 

Aussi, grâce aux types "Params", cela nous permettrait de typer les useParams de react-router : 
```tsx
  const { param }: ParametrizedExampleParams = useParams() as ParametrizedExampleParams;
```

J'ai pour l'instant laisser les examples dans la PR mais on pourra les enlever bien sûr :) 