### PR TITLE
[Fix] ApiHttpClient - Adding type parameter to createHttpFetchRequest

### DIFF
--- a/templates/admin/src/api/ApiHttpClient.ts
+++ b/templates/admin/src/api/ApiHttpClient.ts
@@ -8,11 +8,11 @@ const baseUrl: string = `${window.location.protocol}//${window.location.host}/ap
 export default class ApiHttpClient {
   // eslint-disable-next-line class-methods-use-this
   rawRequest(method: HttpMethod, path: string): HttpRequest<HttpPromise<Response>> {
-    return createHttpFetchRequest(baseUrl, method, path, fetchClient);
+    return createHttpFetchRequest<Response>(baseUrl, method, path, fetchClient);
   }
 
   // eslint-disable-next-line class-methods-use-this
   restRequest<T>(method: HttpMethod, path: string): HttpRequest<HttpPromise<T>> {
-    return createHttpFetchRequest(baseUrl, method, path, defaultJsonFetchClient);
+    return createHttpFetchRequest<T>(baseUrl, method, path, defaultJsonFetchClient);
   }
 }

--- a/templates/front/src/api/ApiHttpClient.ts
+++ b/templates/front/src/api/ApiHttpClient.ts
@@ -8,11 +8,11 @@ const baseUrl: string = `${window.location.protocol}//${window.location.host}/ap
 export default class ApiHttpClient {
   // eslint-disable-next-line class-methods-use-this
   rawRequest(method: HttpMethod, path: string): HttpRequest<HttpPromise<Response>> {
-    return createHttpFetchRequest(baseUrl, method, path, fetchClient);
+    return createHttpFetchRequest<Response>(baseUrl, method, path, fetchClient);
   }
 
   // eslint-disable-next-line class-methods-use-this
   restRequest<T>(method: HttpMethod, path: string): HttpRequest<HttpPromise<T>> {
-    return createHttpFetchRequest(baseUrl, method, path, defaultJsonFetchClient);
+    return createHttpFetchRequest<T>(baseUrl, method, path, defaultJsonFetchClient);
   }
 }

--- a/templates/front/src/components/pages/error/ErrorPage.tsx
+++ b/templates/front/src/components/pages/error/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import { ROUTE_HOME, routes, } from '@components/router/RouterDefinition';
+import { ROUTE_HOME, routes } from '@components/router/RouterDefinition';
 import React from 'react';
 import { Logger } from 'simple-logging-system';
 


### PR DESCRIPTION
@amanteaux correction de l'erreur typescript suivante :

```
src/api/ApiHttpClient.ts:16:5 - error TS2322: Type 'HttpRequest<HttpPromise<unknown>>' is not assignable to type 'HttpRequest<HttpPromise<T>>'
```
